### PR TITLE
Rename prettierrc.js to be .cjs

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('gts/.prettierrc.json'),
+};

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  ...require('gts/.prettierrc.json')
-}

--- a/src/calculateHaftarahNumVerses.ts
+++ b/src/calculateHaftarahNumVerses.ts
@@ -1,6 +1,8 @@
-import { calculateNumVerses } from './common';
+import {calculateNumVerses} from './common';
 
-export function calculateHaftarahNumVerses(haftara: string): number | undefined {
+export function calculateHaftarahNumVerses(
+  haftara: string
+): number | undefined {
   const sections = haftara.split(/[;,]/);
   let total = 0;
   let prevBook = '';

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,6 +1,6 @@
-import { Aliyah } from './types';
-import { calculateNumVerses } from './common';
-import { JsonFestivalAliyah } from './internalTypes';
+import {Aliyah} from './types';
+import {calculateNumVerses} from './common';
+import {JsonFestivalAliyah} from './internalTypes';
 
 /**
  * Makes a deep copy of the src object using JSON stringify and parse
@@ -9,7 +9,11 @@ export function clone(src: any): any {
   return JSON.parse(JSON.stringify(src));
 }
 
-export type Haftarah = Aliyah | Aliyah[] | JsonFestivalAliyah | JsonFestivalAliyah[];
+export type Haftarah =
+  | Aliyah
+  | Aliyah[]
+  | JsonFestivalAliyah
+  | JsonFestivalAliyah[];
 
 export function cloneHaftara(haft: Haftarah): Aliyah | Aliyah[] {
   if (!haft) {
@@ -28,5 +32,7 @@ export function cloneHaftara(haft: Haftarah): Aliyah | Aliyah[] {
  * Returns the total number of verses in an array of Aliyah (or haftarah) objects
  */
 export function sumVerses(aliyot: Haftarah): number {
-  return Array.isArray(aliyot) ? aliyot.reduce((prev, cur) => prev + cur.v!, 0) : aliyot.v!;
+  return Array.isArray(aliyot)
+    ? aliyot.reduce((prev, cur) => prev + cur.v!, 0)
+    : aliyot.v!;
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,11 +1,18 @@
 import numverses from './numverses.json';
-import { Aliyah } from './types';
+import {Aliyah} from './types';
 
 /**
  * Names of the books of the Torah. BOOK[1] === 'Genesis'
  * @readonly
  */
-export const BOOK = ['', 'Genesis', 'Exodus', 'Leviticus', 'Numbers', 'Deuteronomy'];
+export const BOOK = [
+  '',
+  'Genesis',
+  'Exodus',
+  'Leviticus',
+  'Numbers',
+  'Deuteronomy',
+];
 
 /**
  * Formats parsha as a string
@@ -14,7 +21,11 @@ export const BOOK = ['', 'Genesis', 'Exodus', 'Leviticus', 'Numbers', 'Deuterono
 export function parshaToString(parsha: string | string[]): string {
   if (typeof parsha === 'string') {
     return parsha;
-  } else if (!Array.isArray(parsha) || parsha.length === 0 || parsha.length > 2) {
+  } else if (
+    !Array.isArray(parsha) ||
+    parsha.length === 0 ||
+    parsha.length > 2
+  ) {
     throw new TypeError(`Bad parsha argument: ${parsha}`);
   }
   let s = parsha[0];
@@ -25,7 +36,7 @@ export function parshaToString(parsha: string | string[]): string {
 }
 
 type NumVerses = {
-  [key: string]: number[],
+  [key: string]: number[];
 };
 
 /**
@@ -82,4 +93,3 @@ export function formatAliyahShort(aliyah: Aliyah, showBook: boolean): string {
   const end = cv1[0] === cv2[0] ? cv2[1] : end0;
   return `${prefix}${begin}-${end}`;
 }
-

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -1,13 +1,18 @@
-import { Event, HebrewCalendar, HolidayEvent, flags } from '@hebcal/core';
-import { WriteStream } from 'node:fs';
-import { formatAliyahWithBook } from './common';
-import { getLeyningForHoliday, getLeyningForHolidayKey } from './getLeyningForHoliday';
-import { getLeyningKeyForEvent } from './getLeyningKeyForEvent';
-import { getLeyningForParshaHaShavua } from './leyning';
-import { Leyning } from './types';
+import {Event, HebrewCalendar, HolidayEvent, flags} from '@hebcal/core';
+import {WriteStream} from 'node:fs';
+import {formatAliyahWithBook} from './common';
+import {
+  getLeyningForHoliday,
+  getLeyningForHolidayKey,
+} from './getLeyningForHoliday';
+import {getLeyningKeyForEvent} from './getLeyningKeyForEvent';
+import {getLeyningForParshaHaShavua} from './leyning';
+import {Leyning} from './types';
 
 const fmt = new Intl.DateTimeFormat('en-US', {
-  year: 'numeric', month: 'short', day: '2-digit',
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
 });
 
 function fmtDate(dt: Date): string {
@@ -20,7 +25,9 @@ export interface StringToBoolMap {
 }
 
 export function getParshaDates(events: Event[]): StringToBoolMap {
-  const parshaEvents = events.filter((ev) => ev.getFlags() === flags.PARSHA_HASHAVUA);
+  const parshaEvents = events.filter(
+    ev => ev.getFlags() === flags.PARSHA_HASHAVUA
+  );
   const emptyMap: StringToBoolMap = {};
   const parshaDates = parshaEvents.reduce((set, ev) => {
     set[ev.getDate().toString()] = true;
@@ -29,18 +36,27 @@ export function getParshaDates(events: Event[]): StringToBoolMap {
   return parshaDates;
 }
 
-export function writeFullKriyahCsv(stream: WriteStream, hyear: number, il: boolean) {
+export function writeFullKriyahCsv(
+  stream: WriteStream,
+  hyear: number,
+  il: boolean
+) {
   const events0 = HebrewCalendar.calendar({
     year: hyear,
     isHebrewYear: true,
     sedrot: true,
     il: il,
   });
-  const events = events0.filter((ev: Event) => ev.getDesc() !== 'Rosh Chodesh Tevet');
+  const events = events0.filter(
+    (ev: Event) => ev.getDesc() !== 'Rosh Chodesh Tevet'
+  );
   const parshaDates = getParshaDates(events);
   stream.write('"Date","Parashah","Aliyah","Reading","Verses"\r\n');
   for (const ev of events) {
-    if (ev.getFlags() === flags.PARSHA_HASHAVUA || !parshaDates[ev.getDate().toString()]) {
+    if (
+      ev.getFlags() === flags.PARSHA_HASHAVUA ||
+      !parshaDates[ev.getDate().toString()]
+    ) {
       writeFullKriyahEvent(stream, ev, il);
     }
   }
@@ -57,33 +73,58 @@ function ignore(ev: Event): boolean {
   return ev.getDate().getDay() === 6;
 }
 
-export function writeFullKriyahEvent(stream: WriteStream, ev: Event, il: boolean) {
+export function writeFullKriyahEvent(
+  stream: WriteStream,
+  ev: Event,
+  il: boolean
+) {
   if (ignore(ev)) {
     return;
   }
   const mask = ev.getFlags();
   const isParsha = mask === flags.PARSHA_HASHAVUA;
-  const reading = isParsha ? getLeyningForParshaHaShavua(ev, il) : getLeyningForHoliday(ev, il);
+  const reading = isParsha
+    ? getLeyningForParshaHaShavua(ev, il)
+    : getLeyningForHoliday(ev, il);
   if (reading) {
     writeCsvLines(stream, ev, reading, il, isParsha);
     if (!isParsha) {
       writeHolidayMincha(stream, ev as HolidayEvent, il);
       const desc = ev.getDesc();
-      if ((il && desc === 'Sukkot VII (Hoshana Raba)') ||
-          (!il && desc === 'Shmini Atzeret')) {
-        const ev2 = new HolidayEvent(ev.getDate(), 'Erev Simchat Torah', flags.EREV);
+      if (
+        (il && desc === 'Sukkot VII (Hoshana Raba)') ||
+        (!il && desc === 'Shmini Atzeret')
+      ) {
+        const ev2 = new HolidayEvent(
+          ev.getDate(),
+          'Erev Simchat Torah',
+          flags.EREV
+        );
         writeFullKriyahEvent(stream, ev2, il);
       }
     }
   }
 }
 
-export function writeHolidayMincha(stream: WriteStream, ev: HolidayEvent, il: boolean) {
+export function writeHolidayMincha(
+  stream: WriteStream,
+  ev: HolidayEvent,
+  il: boolean
+) {
   const desc = ev.getDesc();
   const minchaDesc1 = desc + ' (Mincha)';
-  const readingMincha1 = getLeyningForHolidayKey(minchaDesc1, ev.cholHaMoedDay, il);
-  const readingMincha = readingMincha1 ||
-    getLeyningForHolidayKey(getLeyningKeyForEvent(ev, il) + ' (Mincha)', ev.cholHaMoedDay, il);
+  const readingMincha1 = getLeyningForHolidayKey(
+    minchaDesc1,
+    ev.cholHaMoedDay,
+    il
+  );
+  const readingMincha =
+    readingMincha1 ||
+    getLeyningForHolidayKey(
+      getLeyningKeyForEvent(ev, il) + ' (Mincha)',
+      ev.cholHaMoedDay,
+      il
+    );
   if (readingMincha) {
     const minchaEv = new Event(ev.getDate(), minchaDesc1, flags.USER_EVENT);
     writeCsvLines(stream, minchaEv, readingMincha, il, false);
@@ -93,8 +134,16 @@ export function writeHolidayMincha(stream: WriteStream, ev: HolidayEvent, il: bo
 /**
  * Formats reading for CSV
  */
-export function writeCsvLines(stream: WriteStream, ev: Event, reading: Leyning, il: boolean, isParsha: boolean) {
-  const parsha = isParsha ? ev.basename() : getLeyningKeyForEvent(ev, il) || ev.render();
+export function writeCsvLines(
+  stream: WriteStream,
+  ev: Event,
+  reading: Leyning,
+  il: boolean,
+  isParsha: boolean
+) {
+  const parsha = isParsha
+    ? ev.basename()
+    : getLeyningKeyForEvent(ev, il) || ev.render();
   const date = fmtDate(ev.getDate().greg());
   const lines = getFullKriyahLines(reading);
   for (const s of lines) {
@@ -134,7 +183,11 @@ function getFullKriyahLines(reading: Leyning): any[] {
     if (reading.reason?.sephardic) {
       sephardic += ' | ' + reading.reason.sephardic;
     }
-    lines.push(['Haftara for Sephardim', sephardic, reading.sephardicNumV || '']);
+    lines.push([
+      'Haftara for Sephardim',
+      sephardic,
+      reading.sephardicNumV || '',
+    ]);
   }
   if (reading.triHaftara) {
     const haftara = reading.triHaftara.replace(/,/g, ';');

--- a/src/festival.ts
+++ b/src/festival.ts
@@ -1,7 +1,7 @@
-import { BOOK } from './common';
-import { clone } from './clone';
+import {BOOK} from './common';
+import {clone} from './clone';
 import festivals0 from './holiday-readings.json';
-import { JsonFestivalLeyning } from './internalTypes';
+import {JsonFestivalLeyning} from './internalTypes';
 
 type Festivals = {
   [key: string]: JsonFestivalLeyning;
@@ -19,7 +19,9 @@ export function hasFestival(holiday: string): boolean {
 /**
  * Returns the raw metadata for festival reading for `holiday`
  */
-export function lookupFestival(holiday: string): JsonFestivalLeyning | undefined {
+export function lookupFestival(
+  holiday: string
+): JsonFestivalLeyning | undefined {
   let src = festivals[holiday];
   if (typeof src === 'undefined') {
     return undefined;

--- a/src/getLeyningForHoliday.ts
+++ b/src/getLeyningForHoliday.ts
@@ -1,18 +1,17 @@
-import { Event, Locale, flags } from '@hebcal/core';
-import { calculateNumVerses } from './common';
-import { clone, cloneHaftara, sumVerses } from './clone';
-import { lookupFestival } from './festival';
-import { HOLIDAY_IGNORE_MASK, getLeyningKeyForEvent } from './getLeyningKeyForEvent';
-import numverses from './numverses.json';
-import { makeLeyningParts, makeSummaryFromParts } from './summary';
+import {Event, Locale, flags} from '@hebcal/core';
+import {calculateNumVerses} from './common';
+import {clone, cloneHaftara, sumVerses} from './clone';
+import {lookupFestival} from './festival';
 import {
-  Aliyah,
-  AliyotMap,
-  Leyning,
-} from './types';
+  HOLIDAY_IGNORE_MASK,
+  getLeyningKeyForEvent,
+} from './getLeyningKeyForEvent';
+import numverses from './numverses.json';
+import {makeLeyningParts, makeSummaryFromParts} from './summary';
+import {Aliyah, AliyotMap, Leyning} from './types';
 
 type NumVerses = {
-  [key: string]: number[],
+  [key: string]: number[];
 };
 
 /**
@@ -21,7 +20,11 @@ type NumVerses = {
  * of full kriyah aliyot, special Maftir, special Haftarah
  * @param key name from `holiday-readings.json` to find
  */
-export function getLeyningForHolidayKey(key?: string, cholHaMoedDay?: number, il?: boolean): Leyning | undefined {
+export function getLeyningForHolidayKey(
+  key?: string,
+  cholHaMoedDay?: number,
+  il?: boolean
+): Leyning | undefined {
   if (typeof key !== 'string') {
     return undefined;
   }
@@ -30,7 +33,11 @@ export function getLeyningForHolidayKey(key?: string, cholHaMoedDay?: number, il
     return undefined;
   }
   const israelOnly = (src as any).il;
-  if (typeof israelOnly === 'boolean' && typeof il === 'boolean' && il !== israelOnly) {
+  if (
+    typeof israelOnly === 'boolean' &&
+    typeof il === 'boolean' &&
+    il !== israelOnly
+  ) {
     return undefined;
   }
   const leyning: any = {
@@ -54,15 +61,17 @@ export function getLeyningForHolidayKey(key?: string, cholHaMoedDay?: number, il
         leyning.summaryParts = parts;
       }
     }
-    Object.values(leyning.fullkriyah).map((aliyah) => calculateNumVerses(aliyah as Aliyah));
+    Object.values(leyning.fullkriyah).map(aliyah =>
+      calculateNumVerses(aliyah as Aliyah)
+    );
   }
   if (src.haft) {
-    const haft = leyning.haft = cloneHaftara(src.haft);
+    const haft = (leyning.haft = cloneHaftara(src.haft));
     leyning.haftara = makeSummaryFromParts(haft);
     leyning.haftaraNumV = sumVerses(haft);
   }
   if (src.seph) {
-    const seph = leyning.seph = cloneHaftara(src.seph);
+    const seph = (leyning.seph = cloneHaftara(src.seph));
     leyning.sephardic = makeSummaryFromParts(seph);
     leyning.sephardicNumV = sumVerses(seph);
   }
@@ -89,7 +98,10 @@ export function getLeyningForHolidayKey(key?: string, cholHaMoedDay?: number, il
  * @param [il] true if Israel holiday scheme
  * @returns map of aliyot
  */
-export function getLeyningForHoliday(ev: Event, il: boolean = false): Leyning | undefined {
+export function getLeyningForHoliday(
+  ev: Event,
+  il = false
+): Leyning | undefined {
   if (typeof ev !== 'object' || typeof ev.getFlags !== 'function') {
     throw new TypeError(`Bad event argument: ${JSON.stringify(ev)}`);
   } else if (typeof (ev as any).eventTime !== 'undefined') {

--- a/src/getLeyningKeyForEvent.ts
+++ b/src/getLeyningKeyForEvent.ts
@@ -1,9 +1,16 @@
-import { Event, HDate, flags, months } from '@hebcal/core';
-import { hasFestival } from './festival';
+import {Event, HDate, flags, months} from '@hebcal/core';
+import {hasFestival} from './festival';
 
-export const HOLIDAY_IGNORE_MASK = flags.DAF_YOMI | flags.OMER_COUNT | flags.SHABBAT_MEVARCHIM |
-  flags.MOLAD | flags.USER_EVENT | flags.HEBREW_DATE | flags.MISHNA_YOMI |
-  flags.MODERN_HOLIDAY | flags.YERUSHALMI_YOMI;
+export const HOLIDAY_IGNORE_MASK =
+  flags.DAF_YOMI |
+  flags.OMER_COUNT |
+  flags.SHABBAT_MEVARCHIM |
+  flags.MOLAD |
+  flags.USER_EVENT |
+  flags.HEBREW_DATE |
+  flags.MISHNA_YOMI |
+  flags.MODERN_HOLIDAY |
+  flags.YERUSHALMI_YOMI;
 
 /**
  * Based on the event date, type and title, finds the relevant leyning key
@@ -11,7 +18,10 @@ export const HOLIDAY_IGNORE_MASK = flags.DAF_YOMI | flags.OMER_COUNT | flags.SHA
  * @param [il] true if Israel holiday scheme
  * @returns key to look up in holiday-reading.json
  */
-export function getLeyningKeyForEvent(ev: Event, il: boolean = false): string | undefined {
+export function getLeyningKeyForEvent(
+  ev: Event,
+  il = false
+): string | undefined {
   if (typeof (ev as any).eventTime !== 'undefined') {
     return undefined;
   }
@@ -28,13 +38,15 @@ export function getLeyningKeyForEvent(ev: Event, il: boolean = false): string | 
   const day = hd.getDate();
   const dow = hd.abs() % 7;
   const month = hd.getMonth();
-  const isShabbat = (dow == 6);
-  const isRoshChodesh = (day == 1 || day == 30);
+  const isShabbat = dow == 6;
+  const isRoshChodesh = day == 1 || day == 30;
   const holiday = ev.basename();
   const isPesach = holiday === 'Pesach';
   if (il && isPesach) {
     if (isShabbat) {
-      return day === 15 || day === 21 ? desc + ' (on Shabbat)' : 'Pesach Shabbat Chol ha-Moed';
+      return day === 15 || day === 21
+        ? desc + ' (on Shabbat)'
+        : 'Pesach Shabbat Chol ha-Moed';
     }
     return desc;
   }
@@ -50,9 +62,9 @@ export function getLeyningKeyForEvent(ev: Event, il: boolean = false): string | 
       return 'Sukkot Final Day (Hoshana Raba)';
     }
     if (isPesach && cholHaMoedDay) {
-      if (dow === 0 && desc === 'Pesach IV (CH\'\'M)') {
+      if (dow === 0 && desc === "Pesach IV (CH''M)") {
         return 'Pesach Chol ha-Moed Day 2 on Sunday';
-      } else if (dow === 1 && desc === 'Pesach V (CH\'\'M)') {
+      } else if (dow === 1 && desc === "Pesach V (CH''M)") {
         return 'Pesach Chol ha-Moed Day 3 on Monday';
       }
     }
@@ -63,7 +75,7 @@ export function getLeyningKeyForEvent(ev: Event, il: boolean = false): string | 
     if (isShabbat && isRoshChodesh) {
       return 'Shabbat Rosh Chodesh Chanukah';
     } else if (isRoshChodesh && chanukahDay == 7) {
-      return `Chanukah Day 7 (on Rosh Chodesh)`;
+      return 'Chanukah Day 7 (on Rosh Chodesh)';
     } else if (isShabbat) {
       return `Chanukah Day ${chanukahDay} (on Shabbat)`;
     } else {
@@ -71,7 +83,10 @@ export function getLeyningKeyForEvent(ev: Event, il: boolean = false): string | 
     }
   }
 
-  if (isRoshChodesh && (desc == 'Shabbat HaChodesh' || desc == 'Shabbat Shekalim')) {
+  if (
+    isRoshChodesh &&
+    (desc == 'Shabbat HaChodesh' || desc == 'Shabbat Shekalim')
+  ) {
     return desc + ' (on Rosh Chodesh)';
   }
 
@@ -126,8 +141,8 @@ export function getLeyningKeyForEvent(ev: Event, il: boolean = false): string | 
     return desc;
   }
 
-  if (desc === 'Tish\'a B\'Av (observed)') {
-    return 'Tish\'a B\'Av';
+  if (desc === "Tish'a B'Av (observed)") {
+    return "Tish'a B'Av";
   }
 
   return undefined;

--- a/src/getLeyningOnDate.ts
+++ b/src/getLeyningOnDate.ts
@@ -1,12 +1,24 @@
 import {
-  HDate, HebrewCalendar, HolidayEvent, ParshaEvent,
-  SedraResult, flags, months
+  HDate,
+  HebrewCalendar,
+  HolidayEvent,
+  ParshaEvent,
+  SedraResult,
+  flags,
+  months,
 } from '@hebcal/core';
-import { getLeyningForHoliday, getLeyningForHolidayKey } from './getLeyningForHoliday';
-import { getLeyningKeyForEvent } from './getLeyningKeyForEvent';
-import { getLeyningForParshaHaShavua, getWeekdayReading, makeLeyningNames } from './leyning';
-import { makeLeyningParts, makeSummaryFromParts } from './summary';
-import { Leyning, LeyningWeekday } from './types';
+import {
+  getLeyningForHoliday,
+  getLeyningForHolidayKey,
+} from './getLeyningForHoliday';
+import {getLeyningKeyForEvent} from './getLeyningKeyForEvent';
+import {
+  getLeyningForParshaHaShavua,
+  getWeekdayReading,
+  makeLeyningNames,
+} from './leyning';
+import {makeLeyningParts, makeSummaryFromParts} from './summary';
+import {Leyning, LeyningWeekday} from './types';
 
 function findParshaHaShavua(saturday: HDate, il: boolean): SedraResult {
   const hyear = saturday.getFullYear();
@@ -34,7 +46,8 @@ function findParshaHaShavua(saturday: HDate, il: boolean): SedraResult {
   const endOfYear = new HDate(1, months.TISHREI, hyear + 1).abs() - 1;
   const endAbs = endOfYear + 30;
   for (let sat2 = saturday.abs() + 7; sat2 <= endAbs; sat2 += 7) {
-    const sedra2 = sat2 > endOfYear ? HebrewCalendar.getSedra(hyear + 1, il) : sedra;
+    const sedra2 =
+      sat2 > endOfYear ? HebrewCalendar.getSedra(hyear + 1, il) : sedra;
     const parsha2 = sedra2.lookup(sat2);
     if (!parsha2.chag) {
       return parsha2;
@@ -61,7 +74,11 @@ function findParshaHaShavua(saturday: HDate, il: boolean): SedraResult {
  * @param {boolean} il in Israel
  * @param {boolean} [wantarray] to return an array of 0 or more readings
  */
-export function getLeyningOnDate(hdate: HDate, il: boolean, wantarray: boolean = false): (Leyning | LeyningWeekday) | (Leyning | LeyningWeekday)[] | undefined {
+export function getLeyningOnDate(
+  hdate: HDate,
+  il: boolean,
+  wantarray = false
+): (Leyning | LeyningWeekday) | (Leyning | LeyningWeekday)[] | undefined {
   const dow = hdate.getDay();
   const arr: (Leyning | LeyningWeekday)[] = [];
   let hasParshaHaShavua = false;
@@ -83,7 +100,9 @@ export function getLeyningOnDate(hdate: HDate, il: boolean, wantarray: boolean =
   const events = HebrewCalendar.getHolidaysOnDate(hdate, il) || [];
   let hasFullKriyah = false;
   for (const ev of events) {
-    const specialShabbat = Boolean(ev.getFlags() & (flags.SPECIAL_SHABBAT | flags.ROSH_CHODESH));
+    const specialShabbat = Boolean(
+      ev.getFlags() & (flags.SPECIAL_SHABBAT | flags.ROSH_CHODESH)
+    );
     if (hasParshaHaShavua && specialShabbat) {
       continue;
     }
@@ -93,7 +112,8 @@ export function getLeyningOnDate(hdate: HDate, il: boolean, wantarray: boolean =
       if (fk) {
         hasFullKriyah = true;
       }
-      const specialMaftirOnly = hasParshaHaShavua && hasFullKriyah && fk.M && !fk['1'];
+      const specialMaftirOnly =
+        hasParshaHaShavua && hasFullKriyah && fk.M && !fk['1'];
       if (!specialMaftirOnly) {
         arr.push(reading);
       }
@@ -103,8 +123,10 @@ export function getLeyningOnDate(hdate: HDate, il: boolean, wantarray: boolean =
       }
       // Special case for Erev Simchat Torah - the only time we read Torah at night
       const desc = ev.getDesc();
-      if ((il && desc === 'Sukkot VII (Hoshana Raba)') ||
-          (!il && desc === 'Shmini Atzeret')) {
+      if (
+        (il && desc === 'Sukkot VII (Hoshana Raba)') ||
+        (!il && desc === 'Shmini Atzeret')
+      ) {
         const erevST = getLeyningForHolidayKey('Erev Simchat Torah');
         arr.push(erevST!);
       }
@@ -137,7 +159,11 @@ function getMincha(ev: HolidayEvent, il: boolean): Leyning | undefined {
   }
   const desc2 = getLeyningKeyForEvent(ev, il);
   if (desc2) {
-    const reading2 = getLeyningForHolidayKey(desc2 + minchaSuffix, ev.cholHaMoedDay, il);
+    const reading2 = getLeyningForHolidayKey(
+      desc2 + minchaSuffix,
+      ev.cholHaMoedDay,
+      il
+    );
     if (reading2) {
       return reading2;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,17 @@ export * from './types';
 export * from './common';
 export * from './summary';
 export * from './festival';
-export { getLeyningKeyForEvent } from './getLeyningKeyForEvent';
+export {getLeyningKeyForEvent} from './getLeyningKeyForEvent';
 export * from './specialReadings';
 export * from './getLeyningForHoliday';
 export * from './leyning';
-export { getLeyningOnDate } from './getLeyningOnDate';
-export { writeFullKriyahCsv, writeCsvLines, writeHolidayMincha,
-  StringToBoolMap, getParshaDates } from './csv';
+export {getLeyningOnDate} from './getLeyningOnDate';
+export {
+  writeFullKriyahCsv,
+  writeCsvLines,
+  writeHolidayMincha,
+  StringToBoolMap,
+  getParshaDates,
+} from './csv';
 // Needed by @hebcal/triennial
 export * from './clone';

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -8,7 +8,7 @@ export type JsonFestivalAliyah = {
 
 export type JsonFestivalAliyotMap = {
   [key: string]: JsonFestivalAliyah;
-}
+};
 
 export type JsonFestivalLeyning = {
   haft?: JsonFestivalAliyah | JsonFestivalAliyah[];

--- a/src/leyning.ts
+++ b/src/leyning.ts
@@ -1,12 +1,10 @@
-import { Event, Locale, ParshaEvent, flags } from '@hebcal/core';
+import {Event, Locale, ParshaEvent, flags} from '@hebcal/core';
 import parshiyotObj0 from './aliyot.json';
-import {
-  BOOK, calculateNumVerses, 
-  parshaToString} from './common';
-import { cloneHaftara, sumVerses } from './clone';
-import { specialReadings2 } from './specialReadings';
-import { makeLeyningParts, makeSummaryFromParts } from './summary';
-import { Aliyah, AliyotMap, Leyning, LeyningNames, ParshaMeta } from './types';
+import {BOOK, calculateNumVerses, parshaToString} from './common';
+import {cloneHaftara, sumVerses} from './clone';
+import {specialReadings2} from './specialReadings';
+import {makeLeyningParts, makeSummaryFromParts} from './summary';
+import {Aliyah, AliyotMap, Leyning, LeyningNames, ParshaMeta} from './types';
 
 type JsonAliyah = {
   k: number | string;
@@ -18,7 +16,7 @@ type JsonAliyah = {
 
 type JsonParshaMap = {
   [key: string]: string[];
-}
+};
 
 type JsonParsha = {
   num: number | number[];
@@ -66,7 +64,7 @@ export function makeLeyningNames(parsha: string[]): LeyningNames {
   const name = parshaToString(parsha);
   return {
     en: name,
-    he: parsha.map((s) => Locale.lookupTranslation(s, 'he')).join('־'),
+    he: parsha.map(s => Locale.lookupTranslation(s, 'he')).join('־'),
   };
 }
 
@@ -104,13 +102,13 @@ function getLeyningForParshaShabbatOnly(parsha: string | string[]): Leyning {
   const hkey = getHaftaraKey(parshaNameArray);
   const haft0 = parshiyotObj[hkey].haft;
   if (haft0) {
-    const haft = result.haft = cloneHaftara(haft0);
+    const haft = (result.haft = cloneHaftara(haft0));
     result.haftara = makeSummaryFromParts(haft);
     result.haftaraNumV = sumVerses(haft);
   }
   const seph0 = parshiyotObj[hkey].seph;
   if (seph0) {
-    const seph = result.seph = cloneHaftara(seph0);
+    const seph = (result.seph = cloneHaftara(seph0));
     result.sephardic = makeSummaryFromParts(seph);
     result.sephardicNumV = sumVerses(seph);
   }
@@ -157,7 +155,7 @@ export function getLeyningForParsha(parsha: string | string[]): Leyning {
  * @param [il] in Israel
  * @returns map of aliyot
  */
-export function getLeyningForParshaHaShavua(ev: Event, il: boolean=false): Leyning {
+export function getLeyningForParshaHaShavua(ev: Event, il = false): Leyning {
   if (typeof ev !== 'object' || typeof ev.getFlags !== 'function') {
     throw new TypeError(`Bad event argument: ${ev}`);
   } else if (ev.getFlags() != flags.PARSHA_HASHAVUA) {
@@ -171,11 +169,11 @@ export function getLeyningForParshaHaShavua(ev: Event, il: boolean=false): Leyni
   const special = specialReadings2(parsha, hd, il, result.fullkriyah);
   const reason = special.reason;
   if (special.haft) {
-    const haft = result.haft = cloneHaftara(special.haft);
+    const haft = (result.haft = cloneHaftara(special.haft));
     result.haftara = makeSummaryFromParts(haft);
     result.haftaraNumV = sumVerses(haft);
     if (special.seph) {
-      const seph = result.seph = cloneHaftara(special.seph);
+      const seph = (result.seph = cloneHaftara(special.seph));
       result.sephardic = makeSummaryFromParts(seph);
       result.sephardicNumV = sumVerses(seph);
     } else if (result.seph) {
@@ -224,11 +222,11 @@ export function lookupParsha(parsha: string | string[]): ParshaMeta {
   if (raw.combined) {
     const [p1, p2] = name.split('-');
     if (!raw.hebrew) {
-      raw.hebrew = Locale.gettext(p1, 'he') + '־' + Locale.gettext(p2, 'he');  
+      raw.hebrew = Locale.gettext(p1, 'he') + '־' + Locale.gettext(p2, 'he');
     }
     if (!raw.haft) {
       const haftKey = p1 === 'Nitzavim' ? p1 : p2;
-      raw.haft = lookupParsha(haftKey).haft;  
+      raw.haft = lookupParsha(haftKey).haft;
     }
   }
   return raw as ParshaMeta;

--- a/src/specialReadings.ts
+++ b/src/specialReadings.ts
@@ -1,15 +1,17 @@
-import { HDate, HebrewCalendar, flags, months } from '@hebcal/core';
-import { clone, cloneHaftara } from './clone';
-import { calculateNumVerses, parshaToString } from './common';
-import { lookupFestival } from './festival';
-import { getLeyningKeyForEvent } from './getLeyningKeyForEvent';
-import { AliyotMap, SpecialReading, StringMap } from './types';
+import {HDate, HebrewCalendar, flags, months} from '@hebcal/core';
+import {clone, cloneHaftara} from './clone';
+import {calculateNumVerses, parshaToString} from './common';
+import {lookupFestival} from './festival';
+import {getLeyningKeyForEvent} from './getLeyningKeyForEvent';
+import {AliyotMap, SpecialReading, StringMap} from './types';
 
 function aliyotCombine67(aliyot: AliyotMap) {
   const a6 = clone(aliyot['6']);
   const a7 = aliyot['7'];
   if (a6.k !== a7.k) {
-    throw new Error('Impossible to combine aliyot 6 & 7: ' + JSON.stringify(aliyot));
+    throw new Error(
+      'Impossible to combine aliyot 6 & 7: ' + JSON.stringify(aliyot)
+    );
   }
   delete aliyot['7'];
   aliyot['6'] = {
@@ -46,7 +48,12 @@ function mergeAliyotWithSpecial(aliyot: AliyotMap, special: AliyotMap) {
  * If a special Haftarah applies, the result will have a `haft` property
  * pointing to Haftarah object and sets `reason.haftara`.
  */
-export function specialReadings2(parsha: string[], hd: HDate, il: boolean, aliyot: AliyotMap): SpecialReading {
+export function specialReadings2(
+  parsha: string[],
+  hd: HDate,
+  il: boolean,
+  aliyot: AliyotMap
+): SpecialReading {
   let haft;
   let seph;
   let specialHaft = false;
@@ -81,7 +88,7 @@ export function specialReadings2(parsha: string[], hd: HDate, il: boolean, aliyo
 
   const parshaName = parshaToString(parsha);
   const events0 = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
-  const events = events0.filter((ev) => !(ev.getFlags() & flags.ROSH_CHODESH));
+  const events = events0.filter(ev => !(ev.getFlags() & flags.ROSH_CHODESH));
   for (const ev of events) {
     if (ev.getDesc() === 'Shabbat Shuva') {
       handleSpecial(`Shabbat Shuva (with ${parshaName})`);
@@ -99,9 +106,10 @@ export function specialReadings2(parsha: string[], hd: HDate, il: boolean, aliyo
       // either on the 14, 16, 17 (in Israel), 19, 21, 23, 24
       handleSpecial('Pinchas occurring after 17 Tammuz');
     } else if (day === 30 || day === 1) {
-      const key = (parshaName === 'Masei' || parshaName === 'Matot-Masei') ?
-        `${parshaName} on Shabbat Rosh Chodesh` :
-        'Shabbat Rosh Chodesh';
+      const key =
+        parshaName === 'Masei' || parshaName === 'Matot-Masei'
+          ? `${parshaName} on Shabbat Rosh Chodesh`
+          : 'Shabbat Rosh Chodesh';
       handleSpecial(key);
     } else if (parshaName === 'Ki Teitzei' && day === 14) {
       // Ki Teitzei is always read in Elul on 9, 11, 13 or 14
@@ -111,7 +119,10 @@ export function specialReadings2(parsha: string[], hd: HDate, il: boolean, aliyo
       // In the book of Isaiah these two brief passages are adjacent."
       // Source: Luaḥ Hashanah, Rabbi Miles B. Cohen and Leslie Rubin
       handleSpecial('Ki Teitzei with 3rd Haftarah of Consolation');
-    } else if (parshaName === 'Kedoshim' && (day === 26 || day === 28 || day === 6)) {
+    } else if (
+      parshaName === 'Kedoshim' &&
+      (day === 26 || day === 28 || day === 6)
+    ) {
       // Kedoshim is read separately from Achrei Mot in ~37% of years.
       // When this happens, it is will be read on
       // 26th or 28th of Nisan (Achrei Mot was Shabbat HaGadol, ~10%),

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -1,13 +1,13 @@
-import { formatAliyahShort } from './common';
-import { Aliyah, AliyotMap } from './types';
+import {formatAliyahShort} from './common';
+import {Aliyah, AliyotMap} from './types';
 
 /**
  * @private
  */
 function isChapVerseBefore(a: string, b: string): boolean {
-  const cv1 = a.split(':').map((x) => +x);
-  const cv2 = b.split(':').map((x) => +x);
-  return (cv1[0]*100 + cv1[1]) < (cv2[0]*100 + cv2[1]);
+  const cv1 = a.split(':').map(x => +x);
+  const cv2 = b.split(':').map(x => +x);
+  return cv1[0] * 100 + cv1[1] < cv2[0] * 100 + cv2[1];
 }
 
 /**
@@ -15,7 +15,7 @@ function isChapVerseBefore(a: string, b: string): boolean {
  * Finds any non-overlapping parts (e.g. special 7th aliyah or maftir)
  */
 export function makeLeyningParts(aliyot: AliyotMap): Aliyah[] {
-  const nums = Object.keys(aliyot).filter((x) => {
+  const nums = Object.keys(aliyot).filter(x => {
     if (x.length === 1) {
       return true;
     }
@@ -28,15 +28,20 @@ export function makeLeyningParts(aliyot: AliyotMap): Aliyah[] {
   for (let i = 0; i < nums.length; i++) {
     const num = nums[i];
     const aliyah = aliyot[num];
-    if ((i === nums.length - 1) && (aliyah.k === end.k) && (aliyah.e === end.e)) {
+    if (i === nums.length - 1 && aliyah.k === end.k && aliyah.e === end.e) {
       // short-circuit when final aliyah is within the previous (e.g. M inside of 7)
       continue;
     }
-    const prevEndChap = +(end.e.split(':')[0]);
-    const curStartChap = +(aliyah.b.split(':')[0]);
-    const sameOrNextChap = curStartChap === prevEndChap || curStartChap === prevEndChap + 1;
-    if ((i !== 0) &&
-      (aliyah.k !== start.k || isChapVerseBefore(aliyah.b, start.e) || !sameOrNextChap)) {
+    const prevEndChap = +end.e.split(':')[0];
+    const curStartChap = +aliyah.b.split(':')[0];
+    const sameOrNextChap =
+      curStartChap === prevEndChap || curStartChap === prevEndChap + 1;
+    if (
+      i !== 0 &&
+      (aliyah.k !== start.k ||
+        isChapVerseBefore(aliyah.b, start.e) ||
+        !sameOrNextChap)
+    ) {
       parts.push({k: start.k, b: start.b, e: end.e});
       start = aliyah;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,11 +17,11 @@ export type Aliyah = {
 
 export type StringMap = {
   [key: string]: string;
-}
+};
 
 export type AliyotMap = {
   [key: string]: Aliyah;
-}
+};
 
 /** Name of the parsha hashavua or holiday */
 export type LeyningNames = {
@@ -29,7 +29,7 @@ export type LeyningNames = {
   en: string;
   /** Hebrew (with nikud) */
   he: string;
-}
+};
 
 /**
  * Parsha metadata (underlying JSON object)
@@ -77,7 +77,6 @@ export type SpecialReading = {
   seph?: Aliyah | Aliyah[];
 };
 
-
 /**
  * Leyning base - weekday, parsha hashavua or holiday
  */
@@ -120,27 +119,27 @@ export type HaftarahProps = {
 /**
  * Shabbat and holiday leyning always has full kriyah and haftarah
  */
-export type LeyningShabbatHoliday = LeyningBase & HaftarahProps & {
-  /** Map of aliyot `1` through `7` plus `M` for maftir */
-  fullkriyah: AliyotMap;
-  /** Haftarah object for Sephardim */
-  seph?: Aliyah | Aliyah[];
-  /** Haftarah for Sephardim, such as `Isaiah 42:5 - 42:21` */
-  sephardic?: string;
-  /** Number of verses in the Haftarah for Sephardim */
-  sephardicNumV?: number;
-  /** Explanations for special readings, keyed by aliyah number, `M` for maftir or `haftara` for Haftarah */
-  reason?: StringMap;
-  /** Song of Songs is read on the sabbath of Passover week, the Book of Ruth on Shavuot, Lamentations on Tisha be-Av, Ecclesiastes on the sabbath of the week of Sukkoth, and the Book of Esther on Purim */
-  megillah?: AliyotMap;
-  /** Triennial alternate Haftara */
-  triHaftara?: string;
-  /** Triennial alternate Haftara number of verses */
-  triHaftaraNumV?: number;
-};
+export type LeyningShabbatHoliday = LeyningBase &
+  HaftarahProps & {
+    /** Map of aliyot `1` through `7` plus `M` for maftir */
+    fullkriyah: AliyotMap;
+    /** Haftarah object for Sephardim */
+    seph?: Aliyah | Aliyah[];
+    /** Haftarah for Sephardim, such as `Isaiah 42:5 - 42:21` */
+    sephardic?: string;
+    /** Number of verses in the Haftarah for Sephardim */
+    sephardicNumV?: number;
+    /** Explanations for special readings, keyed by aliyah number, `M` for maftir or `haftara` for Haftarah */
+    reason?: StringMap;
+    /** Song of Songs is read on the sabbath of Passover week, the Book of Ruth on Shavuot, Lamentations on Tisha be-Av, Ecclesiastes on the sabbath of the week of Sukkoth, and the Book of Esther on Purim */
+    megillah?: AliyotMap;
+    /** Triennial alternate Haftara */
+    triHaftara?: string;
+    /** Triennial alternate Haftara number of verses */
+    triHaftaraNumV?: number;
+  };
 
-export type Leyning =
-  LeyningBase &
+export type Leyning = LeyningBase &
   LeyningParshaHaShavua &
   LeyningShabbatHoliday &
   LeyningWeekday;


### PR DESCRIPTION
This fixes an error caused by `type: "module"`, and makes Prettier work again.

And run Prettier on all files