### PR TITLE
Expose numverses as a constant

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -15,6 +15,16 @@ export const BOOK = [
 ] as const;
 
 /**
+ * The number of verses in each book of the Tanakh.
+ * @readonly
+ */
+export const NUM_VERSES: NumVerses = numverses;
+export type NumVerses = {
+  readonly [book: string]: readonly number[];
+};
+
+
+/**
  * Formats parsha as a string
  * @param parsha untranslated name like 'Pinchas' or ['Pinchas'] or ['Matot','Masei']
  */
@@ -35,10 +45,6 @@ export function parshaToString(parsha: string | string[]): string {
   return s;
 }
 
-type NumVerses = {
-  [key: string]: number[];
-};
-
 /**
  * Calculates the number of verses in an aliyah or haftara based on
  * the `b` (begin verse), `e` (end verse) and `k` (book).
@@ -57,7 +63,7 @@ export function calculateNumVerses(aliyah: Aliyah): number {
   if (c1 === c2) {
     aliyah.v = v2 - v1 + 1;
   } else if (typeof aliyah.k === 'string') {
-    const numv = (numverses as NumVerses)[aliyah.k];
+    const numv = NUM_VERSES[aliyah.k];
     if (typeof numv !== 'object' || !numv.length) {
       throw new ReferenceError(`Can't find numverses for ${aliyah.k}`);
     }

--- a/src/getLeyningForHoliday.ts
+++ b/src/getLeyningForHoliday.ts
@@ -1,18 +1,13 @@
 import {Event, Locale, flags} from '@hebcal/core';
-import {calculateNumVerses} from './common';
+import {calculateNumVerses, NUM_VERSES} from './common';
 import {clone, cloneHaftara, sumVerses} from './clone';
 import {lookupFestival} from './festival';
 import {
   HOLIDAY_IGNORE_MASK,
   getLeyningKeyForEvent,
 } from './getLeyningKeyForEvent';
-import numverses from './numverses.json';
 import {makeLeyningParts, makeSummaryFromParts} from './summary';
 import {Aliyah, AliyotMap, Leyning} from './types';
-
-type NumVerses = {
-  [key: string]: number[];
-};
 
 /**
  * Looks up leyning for a given holiday key. Key should be an
@@ -77,7 +72,7 @@ export function getLeyningForHolidayKey(
   }
   if (src.megillah) {
     const book: string = (src as any).megillah;
-    const chaps = (numverses as NumVerses)[book];
+    const chaps = NUM_VERSES[book];
     const m: AliyotMap = {};
     for (let i = 1; i < chaps.length; i++) {
       const numv = chaps[i];


### PR DESCRIPTION
In my project, I need to duplicate all the data from `numverses` - it'd be super helpful if this was exported by the library. Specifically, I'm using it to get a list of all the verses of an aliyah, e.g. `Genesis 7:17-8:14 -> [Genesis 7:17, Genesis 7:18, ..., Genesis 7:24, Genesis 8:1, ..., Genesis 8:13, Genesis 8:14]`, and that's not possible with just the information that `calculateNumVerses` provides.