### PR TITLE
Add megillah to Leyning.summary

### DIFF
--- a/src/getLeyningForHoliday.ts
+++ b/src/getLeyningForHoliday.ts
@@ -81,6 +81,9 @@ export function getLeyningForHolidayKey(
       m[`${i}`] = {k: megillah, b: `${i}:1`, e: `${i}:${numv}`, v: numv};
     }
     leyning.megillah = m;
+    leyning.summary = leyning.summary
+      ? leyning.summary + '; ' + megillah
+      : megillah;
   }
   if (src.note) {
     leyning.note = src.note;

--- a/test/getLeyningOnDate.spec.js
+++ b/test/getLeyningOnDate.spec.js
@@ -313,7 +313,7 @@ test('getLeyningOnDate-pesach-disaspora', () => {
     {
       d: '2024-04-27',
       n: 'Pesach Shabbat Chol ha-Moed',
-      s: 'Exodus 33:12-34:26; Numbers 28:19-25',
+      s: 'Exodus 33:12-34:26; Numbers 28:19-25; Song of Songs',
     },
     {
       d: '2024-04-28',

--- a/test/holiday.spec.js
+++ b/test/holiday.spec.js
@@ -18,7 +18,7 @@ test('pesach-il', () => {
   }
   const expected = [
     {h: 'Erev Pesach', s: undefined},
-    {h: 'Pesach I', s: 'Exodus 12:21-51; Numbers 28:16-25'},
+    {h: 'Pesach I', s: 'Exodus 12:21-51; Numbers 28:16-25; Song of Songs'},
     {h: 'Pesach II (CH\'\'M)', s: 'Leviticus 22:26-23:44; Numbers 28:19-25'},
     {h: 'Pesach III (CH\'\'M)', s: 'Exodus 13:1-16; Numbers 28:19-25'},
     {h: 'Pesach IV (CH\'\'M)', s: 'Exodus 22:24-23:19; Numbers 28:19-25'},
@@ -72,7 +72,7 @@ test('pesach-shabbat-chm-on-3rd-day', () => {
       d: '2024-04-27',
       h: 'Pesach V (CH\'\'M)',
       k: 'Pesach Shabbat Chol ha-Moed',
-      s: 'Exodus 33:12-34:26; Numbers 28:19-25',
+      s: 'Exodus 33:12-34:26; Numbers 28:19-25; Song of Songs',
     },
     {
       d: '2024-04-28',
@@ -433,7 +433,7 @@ test('Sukkot Shabbat Chol ha-Moed', () => {
       '7': {p: 21, k: 'Exodus', b: '34:18', e: '34:26', v: 9},
       'M': {p: 41, k: 'Numbers', b: '29:26', e: '29:31', v: 6},
     },
-    summary: 'Exodus 33:12-34:26; Numbers 29:26-31',
+    summary: 'Exodus 33:12-34:26; Numbers 29:26-31; Ecclesiastes',
     summaryParts: [
       {k: 'Exodus', b: '33:12', e: '34:26'},
       {k: 'Numbers', b: '29:26', e: '29:31'},
@@ -550,7 +550,7 @@ test('pesach-diaspora-chm-day2-sunday', () => {
       d: '2023-04-08',
       h: 'Pesach III (CH\'\'M)',
       n: 'Pesach Shabbat Chol ha-Moed',
-      s: 'Exodus 33:12-34:26; Numbers 28:19-25',
+      s: 'Exodus 33:12-34:26; Numbers 28:19-25; Song of Songs',
     },
     {
       d: '2023-04-09',
@@ -621,6 +621,7 @@ test('Erev Purim', () => {
       '9': {k: 'Esther', b: '9:1', e: '9:32', v: 32},
       '10': {k: 'Esther', b: '10:1', e: '10:3', v: 3},
     },
+    summary: 'Esther',
   };
   expect(actual).toEqual(expected);
 });


### PR DESCRIPTION
Currently, `getLeyningForHoliday` for Erev Purim returns a Leyning with no summary attribute - I figure it's probably significant enough when there's a megillah reading that it should be in the summary, so for Erev Purim the summary is `"Esther"`, and for e.g. this coming shabbos pesach (`Pesach VII (on Shabbat)`) it's `"Exodus 13:17-15:26; Numbers 28:19-25; Song of Songs"`.